### PR TITLE
Node stream express: correcting package.json build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build:client": "vite build --outDir ../dist/client",
-    "build:server": "vite build --outDir ../dist/server --ssr /serverSideRendering/ServerApp.jsx",
+    "build:client": "vite build --outDir ../dist/client --emptyOutDir",
+    "build:server": "vite build --outDir ../dist/server --ssr /serverSideRendering/ServerApp.jsx --emptyOutDir",
     "build": "npm run build:client && npm run build:server",
     "preview": "vite preview",
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx}\"",

--- a/server/server.js
+++ b/server/server.js
@@ -3,7 +3,6 @@ import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 import renderApp from "../dist/server/ServerApp.js";
-
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Define the port to listen on


### PR DESCRIPTION
added --emptyOutDir to both client and server build scripts, this allows vite to clear our the directories which due to our project structure reside outside of the server.js file folder